### PR TITLE
Add editor-parser

### DIFF
--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -10,15 +10,17 @@ use crate::util::date::Date;
 #[derive(Debug, Clone, Default)]
 pub struct Metadata {
     pub has_keys: bool,
+    // required metadata
     pub abs: Vec<String>,
-    pub canonical_url: Option<String>,
-    pub date: Date,
     pub ed: Option<String>,
-    pub editors: Vec<String>,
-    pub group: Option<String>,
     pub level: Option<String>,
     pub shortname: Option<String>,
     pub raw_status: Option<String>,
+    // optional metadata
+    pub canonical_url: Option<String>,
+    pub date: Date,
+    pub editors: Vec<String>,
+    pub group: Option<String>,
     pub title: Option<String>,
 }
 
@@ -39,6 +41,22 @@ impl Metadata {
                 let val = parse::parse_vec(val);
                 self.abs.extend(val);
             }
+            "ED" => {
+                let val = val.to_owned();
+                self.ed = Some(val);
+            }
+            "Level" => {
+                let val = parse::parse_level(val);
+                self.level = Some(val);
+            }
+            "Shortname" => {
+                let val = val.to_owned();
+                self.shortname = Some(val);
+            }
+            "Status" => {
+                let val = val.to_owned();
+                self.raw_status = Some(val);
+            }
             "Canonical Url" => {
                 let val = val.to_owned();
                 self.canonical_url = Some(val);
@@ -52,10 +70,6 @@ impl Metadata {
                 };
                 self.date = val;
             }
-            "ED" => {
-                let val = val.to_owned();
-                self.ed = Some(val);
-            }
             "Editor" => {
                 let val = parse::parse_editor(val);
                 self.editors.extend(val);
@@ -63,18 +77,6 @@ impl Metadata {
             "Group" => {
                 let val = val.to_owned();
                 self.group = Some(val);
-            }
-            "Level" => {
-                let val = parse::parse_level(val);
-                self.level = Some(val);
-            }
-            "Shortname" => {
-                let val = val.to_owned();
-                self.shortname = Some(val);
-            }
-            "Status" => {
-                let val = val.to_owned();
-                self.raw_status = Some(val);
             }
             "Title" => {
                 let val = val.to_owned();
@@ -95,21 +97,9 @@ impl Metadata {
 
         // Abstract
         self.abs.extend(other.abs.into_iter());
-        // Canonical Url
-        if other.canonical_url.is_some() {
-            self.canonical_url = other.canonical_url;
-        }
-        // Date
-        self.date = other.date;
         // ED
         if other.ed.is_some() {
             self.ed = other.ed;
-        }
-        // Editor
-        self.editors.extend(other.editors.into_iter());
-        // Group
-        if other.group.is_some() {
-            self.group = other.group;
         }
         // Level
         if other.level.is_some() {
@@ -123,6 +113,18 @@ impl Metadata {
         if other.raw_status.is_some() {
             self.raw_status = other.raw_status;
         }
+        // Canonical Url
+        if other.canonical_url.is_some() {
+            self.canonical_url = other.canonical_url;
+        }
+        // Date
+        self.date = other.date;
+        // Editor
+        self.editors.extend(other.editors.into_iter());
+        // Group
+        if other.group.is_some() {
+            self.group = other.group;
+        }
         // Title
         if other.title.is_some() {
             self.title = other.title;
@@ -132,20 +134,15 @@ impl Metadata {
     pub fn fill_macros(&self, doc: &mut Spec) {
         let macros = &mut doc.macros;
 
-        macros.insert(
-            "date",
-            self.date
-                .format(&format!("{} %B %Y", self.date.day()))
-                .to_string(),
-        );
-        macros.insert("isodate", self.date.to_string());
-
+        // level
         if let Some(ref level) = self.level {
             macros.insert("level", level.clone());
         }
+        // shortname
         if let Some(ref shortname) = self.shortname {
             macros.insert("shortname", shortname.clone());
         }
+        // longstatus
         if let Some(ref raw_status) = self.raw_status {
             macros.insert(
                 "longstatus",
@@ -155,6 +152,16 @@ impl Metadata {
                     .to_string(),
             );
         }
+        // date
+        macros.insert(
+            "date",
+            self.date
+                .format(&format!("{} %B %Y", self.date.day()))
+                .to_string(),
+        );
+        // isodate
+        macros.insert("isodate", self.date.to_string());
+        // title & spectitle
         if let Some(ref title) = self.title {
             macros.insert("title", title.clone());
             macros.insert("spectitle", title.clone());

--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -71,7 +71,12 @@ impl Metadata {
                 self.date = val;
             }
             "Editor" => {
-                let val = parse::parse_editor(val);
+                let val = match parse::parse_editor(val) {
+                    Ok(val) => val,
+                    Err(_) => {
+                        die!("\"Editor\" format is \"<name>, <affiliation>?, <email-or-contact-page>?\". Got: {}.", val; line_num)
+                    }
+                };
                 self.editors.extend(val);
             }
             "Group" => {
@@ -181,7 +186,7 @@ impl Metadata {
     }
 }
 
-// TODO(#3): Figure out if we can get rid of this html-parsing-with-regexes.
+// TODO(#3): figure out if we can get rid of this html-parsing-with-regexes
 pub fn parse_metadata(lines: &[Line]) -> (Metadata, Vec<Line>) {
     lazy_static! {
         // title reg
@@ -228,7 +233,7 @@ pub fn parse_metadata(lines: &[Line]) -> (Metadata, Vec<Line>) {
                 last_key = Some(key);
             } else {
                 // wrong key-val pair
-                die!("Incorrectly formatted metadata"; Some(line.index));
+                die!("Incorrectly formatted metadata."; Some(line.index));
             }
         } else if TITLE_REG.is_match(&line.text) {
             // handle title

--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -77,7 +77,7 @@ impl Metadata {
                         die!("\"Editor\" format is \"<name>, <affiliation>?, <email-or-contact-page>?\". Got: {}.", val; line_num)
                     }
                 };
-                self.editors.extend(val);
+                self.editors.push(val);
             }
             "Group" => {
                 let val = val.to_owned();

--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use titlecase::titlecase;
 
-use super::parse;
+use super::parse::{self, Editor};
 use crate::config::SHORT_TO_LONG_STATUS;
 use crate::line::Line;
 use crate::spec::Spec;
@@ -19,13 +19,13 @@ pub struct Metadata {
     // optional metadata
     pub canonical_url: Option<String>,
     pub date: Date,
-    pub editors: Vec<String>,
+    pub editors: Vec<Editor>,
     pub group: Option<String>,
     pub title: Option<String>,
 }
 
 impl Metadata {
-    pub fn new() -> Metadata {
+    pub fn new() -> Self {
         Self::default()
     }
 

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -141,6 +141,8 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
             if is_emailish(last_org_piece) || is_linkish(last_org_piece) {
                 editor.org = Some(org_pieces[..org_pieces.len() - 1].join(" "));
                 editor.org_link = Some(last_org_piece.to_string());
+            } else {
+                editor.org = Some(org_pieces.join(" "));
             }
         } else {
             editor.org = Some(org);
@@ -290,6 +292,12 @@ mod tests {
                 name: "Mario".to_owned(),
                 org: Some("Nintendo".to_owned()),
                 org_link: Some("https://nintendo.com".to_owned()),
+                ..Default::default()
+            }),
+            // org ends without an email or a link
+            "Tommy Vercetti, Rockstar Games" => Ok(Editor {
+                name: "Tommy Vercetti".to_owned(),
+                org: Some("Rockstar Games".to_owned()),
                 ..Default::default()
             }),
             // wrong format

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -11,9 +11,22 @@ pub fn parse_date(val: &str) -> ParseResult {
     }
 }
 
-pub fn parse_editor(val: &str) -> Vec<String> {
-    // TODO: parse editor
-    vec![String::from("TODO: parse editor") + " " + val]
+#[derive(Debug, Clone, Default)]
+pub struct Editor {
+    pub name: String,
+}
+
+impl Editor {
+    pub fn new(name: String) -> Self {
+        Editor { name }
+    }
+}
+
+pub fn parse_editor(val: &str) -> Vec<Editor> {
+    // Editor: <editor-name> [<w3c-id> | <affiliation> | <email> | <homepage>]*
+    let pieces = val.split(",").collect::<Vec<&str>>();
+    let editor = Editor::new(String::from(pieces[0]));
+    vec![editor]
 }
 
 pub fn parse_level(val: &str) -> String {

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -18,6 +18,7 @@ pub struct Editor {
     pub name: String,
     pub w3c_id: Option<String>,
     pub org: Option<String>,
+    pub org_link: Option<String>,
     pub link: Option<String>,
     pub email: Option<String>,
 }
@@ -39,7 +40,7 @@ pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
         // w3c id reg
         static ref W3C_ID_REG: Regex = Regex::new(r"w3cid \d+$").unwrap();
         // link reg
-        static ref LINK_REG: Regex = Regex::new(r"\w+:").unwrap();
+        static ref LINK_REG: Regex = Regex::new(r"^\w+:").unwrap();
         // email reg
         static ref EMAIL_REG: Regex = Regex::new(r".+@.+\..+").unwrap();
     }
@@ -123,6 +124,23 @@ pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
         }
     } else if pieces.len() != 0 {
         return Err("wrong format");
+    }
+
+    // check if the org ends with an email or a link
+    if let Some(org) = editor.org.clone() {
+        if org.contains(" ") {
+            let org_pieces = org
+                .split(" ")
+                .map(|org_piece| org_piece.trim())
+                .collect::<Vec<_>>();
+
+            let last_org_piece = org_pieces.last().unwrap();
+
+            if is_emailish(last_org_piece) || is_linkish(last_org_piece) {
+                editor.org = Some(org_pieces[..org_pieces.len() - 1].join(" "));
+                editor.org_link = Some(last_org_piece.to_string());
+            }
+        }
     }
 
     Ok(vec![editor])

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -131,18 +131,15 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
     // check if the org ends with an email or a link
     if let Some(org) = org {
         if org.contains(" ") {
-            let org_pieces = org
-                .split(" ")
-                .map(|org_piece| org_piece.trim())
-                .collect::<Vec<_>>();
+            let org_pieces = org.rsplitn(2, ' ').collect::<Vec<&str>>();
+            let left_part = org_pieces[1];
+            let last_piece = org_pieces[0];
 
-            let last_org_piece = org_pieces.last().unwrap();
-
-            if is_emailish(last_org_piece) || is_linkish(last_org_piece) {
-                editor.org = Some(org_pieces[..org_pieces.len() - 1].join(" "));
-                editor.org_link = Some(last_org_piece.to_string());
+            if is_emailish(last_piece) || is_linkish(last_piece) {
+                editor.org = Some(left_part.to_owned());
+                editor.org_link = Some(last_piece.to_owned());
             } else {
-                editor.org = Some(org_pieces.join(" "));
+                editor.org = Some([left_part, last_piece].join(" "));
             }
         } else {
             editor.org = Some(org);

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -79,13 +79,15 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
         })
         .collect::<Vec<&str>>();
 
+    let mut org: Option<String> = None;
+
     // handle ambiguous pieces
     if pieces.len() == 3
         && ((is_emailish(pieces[1]) && is_linkish(pieces[2]))
             || (is_linkish(pieces[1]) && is_emailish(pieces[2])))
     {
         // [org, email, link] or [org, link, email]
-        editor.org = Some(pieces[0].to_owned());
+        org = Some(pieces[0].to_owned());
         if is_emailish(pieces[1]) {
             editor.email = Some(pieces[1].to_owned());
             editor.link = Some(pieces[2].to_owned());
@@ -107,7 +109,7 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
         }
     } else if pieces.len() == 2 && (is_emailish(pieces[1]) || is_linkish(pieces[1])) {
         // [org, email] or [org, link]
-        editor.org = Some(pieces[0].to_owned());
+        org = Some(pieces[0].to_owned());
         if is_emailish(pieces[1]) {
             editor.email = Some(pieces[1].to_owned());
         } else {
@@ -120,14 +122,14 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
         } else if is_linkish(pieces[0]) {
             editor.link = Some(pieces[0].to_owned());
         } else {
-            editor.org = Some(pieces[0].to_owned());
+            org = Some(pieces[0].to_owned());
         }
     } else if pieces.len() != 0 {
         return Err("wrong format");
     }
 
     // check if the org ends with an email or a link
-    if let Some(org) = editor.org.clone() {
+    if let Some(org) = org {
         if org.contains(" ") {
             let org_pieces = org
                 .split(" ")
@@ -140,6 +142,8 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
                 editor.org = Some(org_pieces[..org_pieces.len() - 1].join(" "));
                 editor.org_link = Some(last_org_piece.to_string());
             }
+        } else {
+            editor.org = Some(org);
         }
     }
 

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -24,7 +24,7 @@ pub struct Editor {
 }
 
 impl Editor {
-    pub fn new(name: String) -> Self {
+    fn new(name: String) -> Self {
         Editor {
             name,
             ..Default::default()

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -17,6 +17,9 @@ pub fn parse_date(val: &str) -> ParseResult {
 pub struct Editor {
     pub name: String,
     pub w3c_id: Option<String>,
+    pub org: Option<String>,
+    pub link: Option<String>,
+    pub email: Option<String>,
 }
 
 impl Editor {
@@ -28,26 +31,46 @@ impl Editor {
     }
 }
 
-pub fn parse_editor(val: &str) -> Vec<Editor> {
-    // Editor: <editor-name> [<w3c-id> | <affiliation> | <email> | <homepage>]*
+pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
+    // <editor> := <editor-name> <option>
+    // <option> := [<affiliation-name>] [<email> | <link> | (<email> <link>) | (<link> <email>)]
 
     lazy_static! {
-        // w3c id
+        // w3c id reg
         static ref W3C_ID_REG: Regex = Regex::new(r"w3cid \d+$").unwrap();
+        // link reg
+        static ref LINK_REG: Regex = Regex::new(r"\w+:").unwrap();
+        // email reg
+        static ref EMAIL_REG: Regex = Regex::new(r".+@.+\..+").unwrap();
     }
 
+    fn is_linkish(piece: &str) -> bool {
+        LINK_REG.is_match(piece)
+    }
+
+    fn is_emailish(piece: &str) -> bool {
+        EMAIL_REG.is_match(piece)
+    }
+
+    // TODO: unescape pieces
     let mut pieces = val
         .split(",")
         .map(|piece| piece.trim())
         .collect::<Vec<&str>>();
-    let mut editor = Editor::new(String::from(pieces[0]));
 
+    if pieces.is_empty() {
+        return Err("invalid editor");
+    }
+
+    let mut editor = Editor::new(pieces[0].to_owned());
+
+    // extract w3c id
     pieces = pieces[1..]
         .iter()
         .cloned()
         .filter(|piece| {
             if W3C_ID_REG.is_match(piece) && editor.w3c_id.is_none() {
-                editor.w3c_id = Some(String::from(&piece[6..]));
+                editor.w3c_id = Some((&piece[6..]).to_owned());
                 false
             } else {
                 true
@@ -55,7 +78,54 @@ pub fn parse_editor(val: &str) -> Vec<Editor> {
         })
         .collect::<Vec<&str>>();
 
-    vec![editor]
+    // handle ambiguous pieces
+    if pieces.len() == 3
+        && ((is_emailish(pieces[1]) && is_linkish(pieces[2]))
+            || (is_linkish(pieces[1]) && is_emailish(pieces[2])))
+    {
+        // [org, email, link] or [org, link, email]
+        editor.org = Some(pieces[0].to_owned());
+        if is_emailish(pieces[1]) {
+            editor.email = Some(pieces[1].to_owned());
+            editor.link = Some(pieces[2].to_owned());
+        } else {
+            editor.link = Some(pieces[1].to_owned());
+            editor.email = Some(pieces[2].to_owned());
+        }
+    } else if pieces.len() == 2
+        && ((is_emailish(pieces[0]) && is_linkish(pieces[1]))
+            || (is_linkish(pieces[0]) && is_emailish(pieces[1])))
+    {
+        // [email, link] or [link, email]
+        if is_emailish(pieces[0]) {
+            editor.email = Some(pieces[0].to_owned());
+            editor.link = Some(pieces[1].to_owned());
+        } else {
+            editor.link = Some(pieces[0].to_owned());
+            editor.email = Some(pieces[1].to_owned());
+        }
+    } else if pieces.len() == 2 && (is_emailish(pieces[1]) || is_linkish(pieces[1])) {
+        // [org, email] or [org, link]
+        editor.org = Some(pieces[0].to_owned());
+        if is_emailish(pieces[1]) {
+            editor.email = Some(pieces[1].to_owned());
+        } else {
+            editor.link = Some(pieces[1].to_owned());
+        }
+    } else if pieces.len() == 1 {
+        // [org], [email], or [url]
+        if is_emailish(pieces[0]) {
+            editor.email = Some(pieces[0].to_owned());
+        } else if is_linkish(pieces[0]) {
+            editor.link = Some(pieces[0].to_owned());
+        } else {
+            editor.org = Some(pieces[0].to_owned());
+        }
+    } else if pieces.len() != 0 {
+        return Err("wrong format");
+    }
+
+    Ok(vec![editor])
 }
 
 pub fn parse_level(val: &str) -> String {

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -32,7 +32,7 @@ impl Editor {
     }
 }
 
-pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
+pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
     // <editor> := <editor-name> <option>
     // <option> := [<affiliation-name>] [<email> | <link> | (<email> <link>) | (<link> <email>)]
 
@@ -114,7 +114,7 @@ pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
             editor.link = Some(pieces[1].to_owned());
         }
     } else if pieces.len() == 1 {
-        // [org], [email], or [url]
+        // [org], [email], or [link]
         if is_emailish(pieces[0]) {
             editor.email = Some(pieces[0].to_owned());
         } else if is_linkish(pieces[0]) {
@@ -143,7 +143,7 @@ pub fn parse_editor(val: &str) -> Result<Vec<Editor>, &'static str> {
         }
     }
 
-    Ok(vec![editor])
+    Ok(editor)
 }
 
 pub fn parse_level(val: &str) -> String {


### PR DESCRIPTION
This PR adds parser for "editor" metadata. The regexes for email and URL look too loose, but it seems like that's [how they are being used in bikeshed](https://github.com/tabatkins/bikeshed/blob/ca998723f39905fcd5e9deb5fc766e1dfaee76a9/bikeshed/metadata.py#L444), so I just keep them that way.