### PR TITLE
Add editor-term-parser

### DIFF
--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -20,7 +20,7 @@ pub struct Metadata {
     pub canonical_url: Option<String>,
     pub date: Date,
     pub editors: Vec<Editor>,
-    pub editor_term: EditorTerm,
+    pub editor_term: Option<EditorTerm>,
     pub group: Option<String>,
     pub title: Option<String>,
 }
@@ -87,7 +87,7 @@ impl Metadata {
                         die!("\"Editor Term\" format is \"<singular-term>, <plural-term>\". Got: {}.", val; line_num)
                     }
                 };
-                self.editor_term = val;
+                self.editor_term = Some(val);
             }
             "Group" => {
                 let val = val.to_owned();
@@ -137,7 +137,9 @@ impl Metadata {
         // Editor
         self.editors.extend(other.editors.into_iter());
         // Editor Term
-        self.editor_term = other.editor_term;
+        if other.editor_term.is_some() {
+            self.editor_term = other.editor_term;
+        }
         // Group
         if other.group.is_some() {
             self.group = other.group;
@@ -188,6 +190,9 @@ impl Metadata {
     pub fn compute_implicit_metadata(&mut self) {
         if self.canonical_url.as_ref().map_or(true, |url| url == "ED") {
             self.canonical_url = self.ed.clone();
+        }
+        if self.editor_term.is_none() {
+            self.editor_term = Some(EditorTerm::default());
         }
     }
 

--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use titlecase::titlecase;
 
-use super::parse::{self, Editor};
+use super::parse::{self, Editor, EditorTerm};
 use crate::config::SHORT_TO_LONG_STATUS;
 use crate::line::Line;
 use crate::spec::Spec;
@@ -20,6 +20,7 @@ pub struct Metadata {
     pub canonical_url: Option<String>,
     pub date: Date,
     pub editors: Vec<Editor>,
+    pub editor_term: EditorTerm,
     pub group: Option<String>,
     pub title: Option<String>,
 }
@@ -79,6 +80,15 @@ impl Metadata {
                 };
                 self.editors.push(val);
             }
+            "Editor Term" => {
+                let val = match parse::parse_editor_term(val) {
+                    Ok(val) => val,
+                    Err(_) => {
+                        die!("\"Editor Term\" format is \"<singular-term>, <plural-term>\". Got: {}.", val; line_num)
+                    }
+                };
+                self.editor_term = val;
+            }
             "Group" => {
                 let val = val.to_owned();
                 self.group = Some(val);
@@ -126,6 +136,8 @@ impl Metadata {
         self.date = other.date;
         // Editor
         self.editors.extend(other.editors.into_iter());
+        // Editor Term
+        self.editor_term = other.editor_term;
         // Group
         if other.group.is_some() {
             self.group = other.group;

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -125,7 +125,7 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
             org = Some(pieces[0].to_owned());
         }
     } else if pieces.len() != 0 {
-        return Err("wrong format");
+        return Err("wrong editor format");
     }
 
     // check if the org ends with an email or a link
@@ -178,7 +178,7 @@ pub fn parse_editor_term(val: &str) -> Result<EditorTerm, &'static str> {
     if pieces.len() == 2 {
         Ok(EditorTerm::new(pieces[0].to_owned(), pieces[1].to_owned()))
     } else {
-        Err("wrong format")
+        Err("wrong editor term format")
     }
 }
 

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -168,6 +168,8 @@ impl Default for EditorTerm {
 }
 
 pub fn parse_editor_term(val: &str) -> Result<EditorTerm, &'static str> {
+    // <editor-term> := <singular-term> "," <plural-term>
+
     let pieces = val
         .split(",")
         .map(|piece| piece.trim())

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -149,6 +149,37 @@ pub fn parse_editor(val: &str) -> Result<Editor, &'static str> {
     Ok(editor)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct EditorTerm {
+    pub singular: String,
+    pub plural: String,
+}
+
+impl EditorTerm {
+    fn new(singular: String, plural: String) -> Self {
+        EditorTerm { singular, plural }
+    }
+}
+
+impl Default for EditorTerm {
+    fn default() -> Self {
+        EditorTerm::new("Editor".to_owned(), "Editors".to_owned())
+    }
+}
+
+pub fn parse_editor_term(val: &str) -> Result<EditorTerm, &'static str> {
+    let pieces = val
+        .split(",")
+        .map(|piece| piece.trim())
+        .collect::<Vec<&str>>();
+
+    if pieces.len() == 2 {
+        Ok(EditorTerm::new(pieces[0].to_owned(), pieces[1].to_owned()))
+    } else {
+        Err("wrong format")
+    }
+}
+
 pub fn parse_level(val: &str) -> String {
     if val == "none" {
         String::new()
@@ -163,7 +194,7 @@ pub fn parse_vec(val: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_editor, Editor};
+    use super::{parse_editor, parse_editor_term, Editor, EditorTerm};
     use std::collections::BTreeMap;
 
     #[test]
@@ -305,6 +336,20 @@ mod tests {
 
         for (val, target) in cases {
             let result = parse_editor(val);
+            assert_eq!(result, target);
+        }
+    }
+
+    #[test]
+    fn test_parse_editor_term() {
+        let cases: BTreeMap<&'static str, Result<EditorTerm, &'static str>> = btreemap! {
+            "x" => Err("wrong format"),
+            "x, xs" => Ok(EditorTerm::new("x".to_owned(), "xs".to_owned())),
+            "x, xs, xss" => Err("wrong format"),
+        };
+
+        for (val, target) in cases {
+            let result = parse_editor_term(val);
             assert_eq!(result, target);
         }
     }

--- a/src/metadata/parse.rs
+++ b/src/metadata/parse.rs
@@ -331,9 +331,9 @@ mod tests {
                 ..Default::default()
             }),
             // wrong format
-            "Super Mario, Nintendo, error, https://mario.com, hi@mario.com" => Err("wrong format"),
-            "Super Mario, Nintendo, https://mario.com, error, hi@mario.com" => Err("wrong format"),
-            "Super Mario, Nintendo, https://mario.com, hi@mario.com, error" => Err("wrong format"),
+            "Super Mario, Nintendo, error, https://mario.com, hi@mario.com" => Err("wrong editor format"),
+            "Super Mario, Nintendo, https://mario.com, error, hi@mario.com" => Err("wrong editor format"),
+            "Super Mario, Nintendo, https://mario.com, hi@mario.com, error" => Err("wrong editor format"),
         };
 
         for (val, target) in cases {
@@ -345,9 +345,9 @@ mod tests {
     #[test]
     fn test_parse_editor_term() {
         let cases: BTreeMap<&'static str, Result<EditorTerm, &'static str>> = btreemap! {
-            "x" => Err("wrong format"),
+            "x" => Err("wrong editor term format"),
             "x, xs" => Ok(EditorTerm::new("x".to_owned(), "xs".to_owned())),
-            "x, xs, xss" => Err("wrong format"),
+            "x, xs, xss" => Err("wrong editor term format"),
         };
 
         for (val, target) in cases {


### PR DESCRIPTION
This PR adds parser for ["Editor Term"](https://tabatkins.github.io/bikeshed/#metadata-editor-term) metadata and some tests for it.